### PR TITLE
chore: remove console.log from auth service

### DIFF
--- a/electron/auth.ts
+++ b/electron/auth.ts
@@ -82,9 +82,7 @@ export class AuthService {
                 }
             });
 
-            server.listen(3000, () => {
-                console.log('Auth server listening on port 3000');
-            });
+            server.listen(3000);
         });
     }
 


### PR DESCRIPTION
This PR removes a `console.log` statement from `electron/auth.ts` as part of a code health improvement task.

**What:** Removed `console.log('Auth server listening on port 3000');`.
**Why:** To adhere to clean code practices and remove unnecessary noise from the console.
**Verification:** Manually verified the code change and confirmed that `server.listen(3000)` without a callback is valid.
**Result:** Cleaner code in `electron/auth.ts`.

---
*PR created automatically by Jules for task [2206874867901436788](https://jules.google.com/task/2206874867901436788) started by @natanbr*