### PR TITLE
Make event cards clickable to show details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gcal-simplified",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gcal-simplified",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -4,7 +4,8 @@ import { partitionEventsIntoHourlySlots } from '../utils/timeBuckets';
 import { EventCard } from './EventCard';
 import { SettingsModal } from './SettingsModal';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ListTodo, X, RefreshCw, Settings, ChevronLeft, ChevronRight, Calendar } from 'lucide-react';
+import { ListTodo, X, RefreshCw, Settings, ChevronLeft, ChevronRight, Calendar, Clock, MapPin, AlignLeft } from 'lucide-react';
+import { SideDrawer } from './SideDrawer';
 import { groupOverlappingEvents, calculateEventStyles } from '../utils/layout';
 import { AppEvent, AppTask, WeatherData, TideData, UserConfig } from '../types';
 import { WeatherDashboard, getWeatherIcon } from './WeatherDashboard';
@@ -16,6 +17,7 @@ const DAYS_TO_SHOW = 7;
 export const Dashboard: React.FC = () => {
   const [showTasks, setShowTasks] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
+  const [selectedEvent, setSelectedEvent] = useState<AppEvent | null>(null);
   const [selectedLocationId, setSelectedLocationId] = useState('sooke');
   
   const [events, setEvents] = useState<AppEvent[]>([]);
@@ -355,7 +357,7 @@ export const Dashboard: React.FC = () => {
                                              <div className="flex gap-0.5">
                                                 {groupOverlappingEvents(buckets.before).map((group, gIdx) => (
                                                     <div key={`before-${gIdx}`} className="flex-1 min-w-0">
-                                                        {group.map(event => <div key={event.id}><EventCard event={event} /></div>)}
+                                                        {group.map(event => <div key={event.id}><EventCard event={event} onClick={() => setSelectedEvent(event)} /></div>)}
                                                     </div>
                                                 ))}
                                              </div>
@@ -415,7 +417,11 @@ export const Dashboard: React.FC = () => {
                                                                     style={styles}
                                                                 >
                                                                     <div className="h-full w-full">
-                                                                        <EventCard event={event} className="h-full shadow-md" />
+                                                                        <EventCard
+                                                                            event={event}
+                                                                            className="h-full shadow-md"
+                                                                            onClick={() => setSelectedEvent(event)}
+                                                                        />
                                                                     </div>
                                                                 </div>
                                                             )
@@ -430,7 +436,7 @@ export const Dashboard: React.FC = () => {
                                              <div className="flex gap-0.5">
                                                 {groupOverlappingEvents(buckets.after).map((group, gIdx) => (
                                                     <div key={`after-${gIdx}`} className="flex-1 min-w-0">
-                                                        {group.map(event => <div key={event.id}><EventCard event={event} /></div>)}
+                                                        {group.map(event => <div key={event.id}><EventCard event={event} onClick={() => setSelectedEvent(event)} /></div>)}
                                                     </div>
                                                 ))}
                                              </div>
@@ -487,6 +493,67 @@ export const Dashboard: React.FC = () => {
             />
         )}
       </AnimatePresence>
+
+      <SideDrawer
+        isOpen={!!selectedEvent}
+        onClose={() => setSelectedEvent(null)}
+        title="Event Details"
+      >
+            {selectedEvent && (
+                <div className="space-y-8">
+                    <div>
+                        <h3 className="text-3xl font-black text-white leading-tight mb-2">
+                            {selectedEvent.title}
+                        </h3>
+                        <div className="flex items-center gap-2 text-zinc-400 font-medium">
+                            <Clock size={18} className="text-family-cyan" />
+                            <span>
+                                {selectedEvent.allDay
+                                    ? 'All Day'
+                                    : `${format(selectedEvent.start, 'EEEE, MMMM d')} • ${format(selectedEvent.start, 'HH:mm')} - ${format(selectedEvent.end, 'HH:mm')}`
+                                }
+                            </span>
+                        </div>
+                    </div>
+
+                    {selectedEvent.location && (
+                        <div className="space-y-2">
+                            <div className="flex items-center gap-2 text-zinc-300 font-bold uppercase tracking-wider text-xs">
+                                <MapPin size={16} className="text-family-orange" />
+                                <span>Location</span>
+                            </div>
+                            <div className="text-zinc-400 bg-zinc-800/50 p-4 rounded-xl border border-zinc-700/30">
+                                {selectedEvent.location}
+                            </div>
+                        </div>
+                    )}
+
+                    {selectedEvent.description && (
+                        <div className="space-y-2">
+                            <div className="flex items-center gap-2 text-zinc-300 font-bold uppercase tracking-wider text-xs">
+                                <AlignLeft size={16} className="text-family-cyan" />
+                                <span>Description</span>
+                            </div>
+                            <div className="text-zinc-400 bg-zinc-800/50 p-4 rounded-xl border border-zinc-700/30 whitespace-pre-wrap leading-relaxed">
+                                {selectedEvent.description}
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Meta info */}
+                    <div className="pt-8 border-t border-zinc-800 flex flex-wrap gap-4">
+                        <div className="px-3 py-1 rounded-full bg-zinc-800 text-zinc-500 text-[10px] font-black uppercase tracking-widest">
+                            ID: {selectedEvent.id.substring(0, 8)}...
+                        </div>
+                        {selectedEvent.isHoliday && (
+                            <div className="px-3 py-1 rounded-full bg-family-orange/20 text-family-orange text-[10px] font-black uppercase tracking-widest">
+                                Public Holiday
+                            </div>
+                        )}
+                    </div>
+                </div>
+            )}
+      </SideDrawer>
     </div>
   );
 };

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -10,6 +10,7 @@ import {
 interface EventCardProps {
   event: AppEvent;
   className?: string;
+  onClick?: () => void;
 }
 
 import { getEventColorStyles } from '../utils/colorMapping';
@@ -37,7 +38,7 @@ const getEventIcon = (title: string, description?: string) => {
   return null;
 };
 
-export const EventCard: React.FC<EventCardProps> = ({ event, className }) => {
+export const EventCard: React.FC<EventCardProps> = ({ event, className, onClick }) => {
   const colorStyles = useMemo(
     () => getEventColorStyles(event.title, event.description, event.colorId, event.color),
     [event.title, event.description, event.colorId, event.color]
@@ -58,8 +59,12 @@ export const EventCard: React.FC<EventCardProps> = ({ event, className }) => {
       data-testid={`event-card-${event.id}`}
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
+      whileHover={{ scale: 1.01 }}
+      whileTap={{ scale: 0.98 }}
+      onClick={onClick}
       className={clsx(
-        'w-full rounded-md shadow-sm border-l-[3px] text-sm overflow-hidden leading-tight',
+        'w-full rounded-md shadow-sm border-l-[3px] text-sm overflow-hidden leading-tight transition-shadow hover:shadow-md',
+        onClick && 'cursor-pointer',
         isShortEvent ? 'p-0' : 'p-1',
         colorStyles.className,
         className


### PR DESCRIPTION
This change makes event cards in the calendar grid clickable. When clicked, a side drawer opens to display the full details of the event, including its title, a formatted time range (or "All Day"), location, and description. This addresses the issue where squeezed or narrow cards hide important information. The implementation uses Framer Motion for smooth transitions and Lucide React for consistent iconography.

Fixes #9

---
*PR created automatically by Jules for task [3753726975553056039](https://jules.google.com/task/3753726975553056039) started by @natanbr*