### PR TITLE
🛡️ Sentinel: [HIGH] Implement strict IPC allowlist and remove unused methods

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,27 +1,45 @@
 import { ipcRenderer, contextBridge } from 'electron'
 
+// Whitelist of allowed channels
+const ALLOWED_INVOKE_CHANNELS = [
+  'auth:login',
+  'auth:logout',
+  'auth:check',
+  'data:events',
+  'data:tasks',
+  'data:calendars',
+  'data:tasklists',
+  'settings:get',
+  'settings:save',
+  'weather:get',
+  'tides:get'
+];
+
+const ALLOWED_ON_CHANNELS = [
+  'auth:success',
+  'main-process-message'
+];
+
 // --------- Expose some API to the Renderer process ---------
 contextBridge.exposeInMainWorld('ipcRenderer', {
   on(channel: string, listener: (...args: unknown[]) => void) {
+    if (!ALLOWED_ON_CHANNELS.includes(channel)) {
+      console.warn(`Blocked unauthorized IPC listener: ${channel}`);
+      return () => {};
+    }
     const subscription = (_event: unknown, ...args: unknown[]) => listener(...args)
     ipcRenderer.on(channel, subscription)
     return () => {
       ipcRenderer.removeListener(channel, subscription)
     }
   },
-  off(...args: Parameters<typeof ipcRenderer.off>) {
-    const [channel, ...omit] = args
-    return ipcRenderer.off(channel, ...omit)
+  // 'off' is removed as it's redundant with the cleanup function from 'on' and unused directly
+  // 'send' is removed as it is unused
+  invoke(channel: string, ...args: unknown[]) {
+    if (!ALLOWED_INVOKE_CHANNELS.includes(channel)) {
+      console.error(`Blocked unauthorized IPC invoke: ${channel}`);
+      return Promise.reject(new Error(`Unauthorized IPC channel: ${channel}`));
+    }
+    return ipcRenderer.invoke(channel, ...args)
   },
-  send(...args: Parameters<typeof ipcRenderer.send>) {
-    const [channel, ...omit] = args
-    return ipcRenderer.send(channel, ...omit)
-  },
-  invoke(...args: Parameters<typeof ipcRenderer.invoke>) {
-    const [channel, ...omit] = args
-    return ipcRenderer.invoke(channel, ...omit)
-  },
-
-  // You can expose other APTs you need here.
-  // ...
 })

--- a/src/utils/weatherIcons.tsx
+++ b/src/utils/weatherIcons.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Cloud, CloudDrizzle, CloudFog, CloudLightning,
     CloudRain, CloudSnow, Sun

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,7 +5,6 @@ interface Window {
     ipcRenderer: {
         invoke(channel: string, ...args: unknown[]): Promise<unknown>;
         on(channel: string, listener: (...args: unknown[]) => void): () => void;
-        off(channel: string, ...args: unknown[]): unknown;
-        send(channel: string, ...args: unknown[]): void;
+        // 'off' and 'send' are removed for security
     }
 }


### PR DESCRIPTION
This PR enhances the security of the Electron application by restricting the Inter-Process Communication (IPC) between the renderer and the main process.

### Security Enhancements
- **IPC Allowlisting:** The `electron/preload.ts` file now enforces a strict allowlist for IPC channels. Only explicitly approved channels (e.g., `auth:login`, `data:events`, `settings:save`) can be invoked or listened to by the renderer.
- **Attack Surface Reduction:** The `ipcRenderer.send` and `ipcRenderer.off` methods have been removed from the exposed API in the renderer context, as they were identified as unused and potential vectors for misuse.
- **Type Safety:** The `src/vite-env.d.ts` file has been updated to match the new runtime API, ensuring TypeScript correctly flags any attempts to use the removed methods.

### Verification
- **Build:** `npm run build` passes successfully (fixing a minor unused import warning in `weatherIcons.tsx`).
- **Tests:** `npm run test:unit` passes (62 tests), confirming no regressions in core functionality.

This change prevents a compromised renderer (e.g., via XSS) from accessing unauthorized backend functionality or internal Electron events.

---
*PR created automatically by Jules for task [6436923971657041392](https://jules.google.com/task/6436923971657041392) started by @natanbr*