### PR TITLE
Sentinel: [CRITICAL] Restrict IPC channels and remove insecure methods

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,25 +1,42 @@
 import { ipcRenderer, contextBridge } from 'electron'
 
+const ALLOWED_INVOKE_CHANNELS = [
+  'auth:login',
+  'auth:logout',
+  'auth:check',
+  'data:events',
+  'data:tasks',
+  'data:calendars',
+  'data:tasklists',
+  'settings:get',
+  'settings:save',
+  'weather:get',
+  'tides:get'
+]
+
+const ALLOWED_ON_CHANNELS = [
+  'auth:success',
+  'main-process-message'
+]
+
 // --------- Expose some API to the Renderer process ---------
 contextBridge.exposeInMainWorld('ipcRenderer', {
   on(channel: string, listener: (...args: unknown[]) => void) {
+    if (!ALLOWED_ON_CHANNELS.includes(channel)) {
+      throw new Error(`Unauthorized IPC channel: ${channel}`)
+    }
     const subscription = (_event: unknown, ...args: unknown[]) => listener(...args)
     ipcRenderer.on(channel, subscription)
     return () => {
       ipcRenderer.removeListener(channel, subscription)
     }
   },
-  off(...args: Parameters<typeof ipcRenderer.off>) {
-    const [channel, ...omit] = args
-    return ipcRenderer.off(channel, ...omit)
-  },
-  send(...args: Parameters<typeof ipcRenderer.send>) {
-    const [channel, ...omit] = args
-    return ipcRenderer.send(channel, ...omit)
-  },
-  invoke(...args: Parameters<typeof ipcRenderer.invoke>) {
-    const [channel, ...omit] = args
-    return ipcRenderer.invoke(channel, ...omit)
+  // off and send are removed for security
+  invoke(channel: string, ...args: unknown[]) {
+    if (!ALLOWED_INVOKE_CHANNELS.includes(channel)) {
+      throw new Error(`Unauthorized IPC channel: ${channel}`)
+    }
+    return ipcRenderer.invoke(channel, ...args)
   },
 
   // You can expose other APTs you need here.

--- a/src/utils/weatherIcons.tsx
+++ b/src/utils/weatherIcons.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Cloud, CloudDrizzle, CloudFog, CloudLightning,
     CloudRain, CloudSnow, Sun

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,7 +5,5 @@ interface Window {
     ipcRenderer: {
         invoke(channel: string, ...args: unknown[]): Promise<unknown>;
         on(channel: string, listener: (...args: unknown[]) => void): () => void;
-        off(channel: string, ...args: unknown[]): unknown;
-        send(channel: string, ...args: unknown[]): void;
     }
 }


### PR DESCRIPTION
Sentinel: [CRITICAL] Restrict IPC channels and remove insecure methods

🛡️ **Sentinel Report**

**Severity:** CRITICAL
**Vulnerability:** Unrestricted IPC access allowing arbitrary messages from renderer to main process.
**Impact:** A compromised renderer (e.g., via XSS) could control the backend by sending arbitrary IPC messages or invoking restricted handlers.
**Fix:**
- Implemented strict allowlists for `invoke` and `on` channels in `electron/preload.ts`.
- Removed `ipcRenderer.send` and `ipcRenderer.off` from the exposed context bridge.
- Updated TypeScript definitions to match the hardened API.
**Verification:**
- Ran `npm run build` to ensure type safety and successful compilation.
- Verified that `send` and `off` are not used in the application source code.


---
*PR created automatically by Jules for task [10600237675882547861](https://jules.google.com/task/10600237675882547861) started by @natanbr*