### PR TITLE
Add setting to control calendar first day of week

### DIFF
--- a/electron/store.ts
+++ b/electron/store.ts
@@ -15,6 +15,8 @@ export interface UserConfig {
     sleepEnabled?: boolean;
     sleepStart?: number;     // 0-23
     sleepEnd?: number;       // 0-23
+
+    weekStartDay?: 'sunday' | 'monday' | 'today';
 }
 
 let configPath = '';
@@ -40,7 +42,8 @@ export const store = {
                     manualDayEnd: 19,
                     sleepEnabled: true,
                     sleepStart: 22,
-                    sleepEnd: 6
+                    sleepEnd: 6,
+                    weekStartDay: 'today'
                 };
             }
             const loaded = JSON.parse(fs.readFileSync(p, 'utf-8'));
@@ -55,7 +58,8 @@ export const store = {
                 manualDayEnd: loaded.manualDayEnd ?? 19,
                 sleepEnabled: loaded.sleepEnabled ?? true,
                 sleepStart: loaded.sleepStart ?? 22,
-                sleepEnd: loaded.sleepEnd ?? 6
+                sleepEnd: loaded.sleepEnd ?? 6,
+                weekStartDay: loaded.weekStartDay || 'today'
             };
         } catch (e) {
             console.error("Failed to read config", e);
@@ -67,7 +71,8 @@ export const store = {
                 manualDayEnd: 19,
                 sleepEnabled: true,
                 sleepStart: 22,
-                sleepEnd: 6
+                sleepEnd: 6,
+                weekStartDay: 'today'
             };
         }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gcal-simplified",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gcal-simplified",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -40,7 +40,7 @@ export const Dashboard: React.FC = () => {
   useTheme(config, weather);
 
   const today = useMemo(() => new Date(), []);
-  const startDate = weekOffset === 0 ? today : getWeekStartDate(today, weekOffset);
+  const startDate = useMemo(() => getWeekStartDate(today, weekOffset, config.weekStartDay), [today, weekOffset, config.weekStartDay]);
   const days = useMemo(() => Array.from({ length: DAYS_TO_SHOW }, (_, i) => addDays(startDate, i)), [startDate]);
 
   const eventsByDay = useMemo(() => {
@@ -55,7 +55,7 @@ export const Dashboard: React.FC = () => {
       setLoading(true);
       setError(null);
       try {
-          const fetchStart = currentOffset === 0 ? today : getWeekStartDate(today, currentOffset);
+          const fetchStart = getWeekStartDate(today, currentOffset, config.weekStartDay);
           const fetchEnd = addDays(fetchStart, 8);
 
           setLoadingMessage('Fetching Events...');
@@ -89,7 +89,7 @@ export const Dashboard: React.FC = () => {
       } finally {
           setLoading(false);
       }
-  }, [weekOffset, today, currentLocation]);
+  }, [weekOffset, today, currentLocation, config.weekStartDay]);
 
   const fetchTides = useCallback(async () => {
     setIsTidesLoading(true);

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import { X, Save, Check, RefreshCw, Moon, Sun, Power } from 'lucide-react';
+import { X, Save, Check, RefreshCw, Moon, Sun, Power, Calendar } from 'lucide-react';
 import { CalendarSource, TaskListSource, UserConfig } from '../types';
 
 interface SettingsModalProps {
@@ -132,6 +132,33 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ onClose, onSave })
                     </div>
 
                     
+                    {/* Calendar View Settings */}
+                    <div className="lg:col-span-2 border-t border-zinc-200 dark:border-zinc-800 pt-8 mt-4">
+                        <h3 className="text-lg font-bold text-family-cyan uppercase tracking-widest mb-4 flex items-center gap-2">
+                           <Calendar size={20} /> Calendar View
+                        </h3>
+                        <div className="bg-zinc-50 dark:bg-zinc-950 p-6 rounded-xl border border-zinc-200 dark:border-zinc-800 space-y-4">
+                            <h4 className="text-sm font-bold text-zinc-500 uppercase tracking-wider">Week Starts On</h4>
+                            <div className="flex gap-2">
+                                {(['today', 'sunday', 'monday'] as const).map((mode) => (
+                                    <button
+                                        key={mode}
+                                        onClick={() => setConfig(prev => ({ ...prev, weekStartDay: mode }))}
+                                        className={`flex-1 py-2 px-4 rounded-lg font-bold text-sm transition-all uppercase tracking-wider ${config.weekStartDay === mode || (mode === 'today' && !config.weekStartDay) ? 'bg-family-cyan text-white shadow-lg shadow-family-cyan/20' : 'bg-zinc-200 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 hover:bg-zinc-300 dark:hover:bg-zinc-700'}`}
+                                        data-testid={`week-start-${mode}-button`}
+                                    >
+                                        {mode}
+                                    </button>
+                                ))}
+                            </div>
+                            <p className="text-xs text-zinc-500">
+                                {config.weekStartDay === 'sunday' ? "Calendar will start from Sunday of the current week." :
+                                 config.weekStartDay === 'monday' ? "Calendar will start from Monday of the current week." :
+                                 "Calendar will start from today and show the next 7 days."}
+                            </p>
+                        </div>
+                    </div>
+
                     {/* Active Hours Section */}
                     <div className="lg:col-span-2 border-t border-zinc-200 dark:border-zinc-800 pt-8 mt-4">
                         <h3 className="text-lg font-bold text-orange-500 dark:text-orange-400 uppercase tracking-widest mb-4">

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,8 @@ export interface UserConfig {
     sleepEnabled?: boolean;  // Default true
     sleepStart?: number;     // 0-23 (Default 22)
     sleepEnd?: number;       // 0-23 (Default 6)
+
+    weekStartDay?: 'sunday' | 'monday' | 'today';
 }
 
 export interface WeatherData {

--- a/src/utils/__tests__/weekNavigation.test.ts
+++ b/src/utils/__tests__/weekNavigation.test.ts
@@ -1,53 +1,64 @@
 import { describe, it, expect } from 'vitest';
 import { getWeekStartDate, canNavigateToPreviousWeek, isCurrentWeek } from '../weekNavigation';
-import { addDays, format } from 'date-fns';
+import { format } from 'date-fns';
 
 describe('weekNavigation', () => {
     describe('getWeekStartDate', () => {
-        it('should return Monday of the current week when offset is 0', () => {
-            // Wednesday, Feb 5, 2026
-            const wednesday = new Date(2026, 1, 4, 18, 41, 50); // Month is 0-indexed
-            const result = getWeekStartDate(wednesday, 0);
+        describe('today mode (default)', () => {
+            it('should return the reference date when offset is 0', () => {
+                // Wednesday, Feb 4, 2026
+                const wednesday = new Date(2026, 1, 4, 18, 41, 50);
+                const result = getWeekStartDate(wednesday, 0, 'today');
+                expect(format(result, 'yyyy-MM-dd')).toBe('2026-02-04');
+            });
 
-            // Should return Monday, Feb 2, 2026
-            expect(format(result, 'yyyy-MM-dd')).toBe('2026-02-02');
-            expect(result.getDay()).toBe(1); // Monday
+            it('should return same day next week when offset is 1', () => {
+                const wednesday = new Date(2026, 1, 4, 18, 41, 50);
+                const result = getWeekStartDate(wednesday, 1, 'today');
+                expect(format(result, 'yyyy-MM-dd')).toBe('2026-02-11');
+            });
         });
 
-        it('should return Monday of next week when offset is 1', () => {
-            const wednesday = new Date(2026, 1, 4, 18, 41, 50);
-            const result = getWeekStartDate(wednesday, 1);
+        describe('monday mode', () => {
+            it('should return Monday of the current week when offset is 0', () => {
+                // Wednesday, Feb 4, 2026
+                const wednesday = new Date(2026, 1, 4, 18, 41, 50);
+                const result = getWeekStartDate(wednesday, 0, 'monday');
 
-            // Should return Monday, Feb 9, 2026
-            expect(format(result, 'yyyy-MM-dd')).toBe('2026-02-09');
-            expect(result.getDay()).toBe(1); // Monday
+                // Should return Monday, Feb 2, 2026
+                expect(format(result, 'yyyy-MM-dd')).toBe('2026-02-02');
+                expect(result.getDay()).toBe(1); // Monday
+            });
+
+            it('should return Monday of next week when offset is 1', () => {
+                const wednesday = new Date(2026, 1, 4, 18, 41, 50);
+                const result = getWeekStartDate(wednesday, 1, 'monday');
+
+                // Should return Monday, Feb 9, 2026
+                expect(format(result, 'yyyy-MM-dd')).toBe('2026-02-09');
+                expect(result.getDay()).toBe(1); // Monday
+            });
         });
 
-        it('should return Monday of previous week when offset is -1', () => {
-            const wednesday = new Date(2026, 1, 4, 18, 41, 50);
-            const result = getWeekStartDate(wednesday, -1);
+        describe('sunday mode', () => {
+            it('should return Sunday of the current week when offset is 0', () => {
+                // Wednesday, Feb 4, 2026
+                const wednesday = new Date(2026, 1, 4, 18, 41, 50);
+                const result = getWeekStartDate(wednesday, 0, 'sunday');
 
-            // Should return Monday, Jan 26, 2026
-            expect(format(result, 'yyyy-MM-dd')).toBe('2026-01-26');
-            expect(result.getDay()).toBe(1); // Monday
-        });
+                // Should return Sunday, Feb 1, 2026
+                expect(format(result, 'yyyy-MM-dd')).toBe('2026-02-01');
+                expect(result.getDay()).toBe(0); // Sunday
+            });
 
-        it('should always return Monday even when reference date is Sunday', () => {
-            const sunday = new Date(2026, 1, 8); // Sunday, Feb 8, 2026
-            const result = getWeekStartDate(sunday, 0);
+            it('should return Sunday of next week when offset is 1', () => {
+                const wednesday = new Date(2026, 1, 4, 18, 41, 50);
+                const result = getWeekStartDate(wednesday, 1, 'sunday');
 
-            // Should return Monday, Feb 2, 2026 (start of the week containing this Sunday)
-            expect(format(result, 'yyyy-MM-dd')).toBe('2026-02-02');
-            expect(result.getDay()).toBe(1); // Monday
-        });
-
-        it('should always return Monday even when reference date is Monday', () => {
-            const monday = new Date(2026, 1, 2); // Monday, Feb 2, 2026
-            const result = getWeekStartDate(monday, 0);
-
-            // Should return the same Monday
-            expect(format(result, 'yyyy-MM-dd')).toBe('2026-02-02');
-            expect(result.getDay()).toBe(1); // Monday
+                // Should return Sunday, Feb 8, 2026
+                expect(format(result, 'yyyy-MM-dd')).toBe('2026-02-08');
+                expect(result.getDay()).toBe(0); // Sunday
+            });
         });
     });
 

--- a/src/utils/weekNavigation.ts
+++ b/src/utils/weekNavigation.ts
@@ -1,11 +1,18 @@
 import { startOfWeek, addWeeks } from 'date-fns';
 
+export type WeekStartDay = 'sunday' | 'monday' | 'today';
+
 /**
- * Get the start date for a week view (always Monday)
+ * Get the start date for a week view
  */
-export function getWeekStartDate(referenceDate: Date, weekOffset: number): Date {
-    const monday = startOfWeek(referenceDate, { weekStartsOn: 1 }); // 1 = Monday
-    return addWeeks(monday, weekOffset);
+export function getWeekStartDate(referenceDate: Date, weekOffset: number, weekStartDay: WeekStartDay = 'today'): Date {
+    if (weekStartDay === 'today') {
+        return addWeeks(referenceDate, weekOffset);
+    }
+
+    const weekStartsOn = weekStartDay === 'sunday' ? 0 : 1;
+    const startOfThisWeek = startOfWeek(referenceDate, { weekStartsOn });
+    return addWeeks(startOfThisWeek, weekOffset);
 }
 
 /**


### PR DESCRIPTION
This change implements a user-requested feature to control the first day of the calendar. Users can now choose between:
- Today (default): Shows 7 days starting from today.
- Sunday: Shows the full week starting from the current week's Sunday.
- Monday: Shows the full week starting from the current week's Monday.

The setting is persisted in the application configuration and affects both the initial view and week-to-week navigation.

Fixes #29

---
*PR created automatically by Jules for task [2894228441667048490](https://jules.google.com/task/2894228441667048490) started by @natanbr*