### PR TITLE
⚡ Bolt: Prevent EventCard re-renders

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -15,6 +15,7 @@ interface EventCardProps {
 }
 
 import { getEventColorStyles } from '../utils/colorMapping';
+import { areEventCardPropsEqual } from '../utils/eventUtils';
 
 // Icon mapping for specific event types
 const getEventIcon = (title: string, description?: string) => {
@@ -115,4 +116,4 @@ export const EventCard: React.FC<EventCardProps> = memo(({ event, className, onC
       )}
     </motion.div>
   );
-});
+}, areEventCardPropsEqual);

--- a/src/utils/eventUtils.test.ts
+++ b/src/utils/eventUtils.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { areEventsEqual, areEventCardPropsEqual } from './eventUtils';
+import { AppEvent } from '../types';
+
+describe('areEventsEqual', () => {
+    const baseEvent: AppEvent = {
+        id: 'evt_1',
+        title: 'Meeting',
+        start: new Date('2024-01-01T10:00:00Z'),
+        end: new Date('2024-01-01T11:00:00Z'),
+        allDay: false,
+        location: 'Room A',
+        description: 'Discuss things',
+        colorId: '1',
+        color: '#ff0000',
+    };
+
+    it('returns true for same object reference', () => {
+        expect(areEventsEqual(baseEvent, baseEvent)).toBe(true);
+    });
+
+    it('returns true for deep equal objects with new references', () => {
+        const event2 = {
+            ...baseEvent,
+            start: new Date(baseEvent.start), // New Date object
+            end: new Date(baseEvent.end),     // New Date object
+        };
+        expect(areEventsEqual(baseEvent, event2)).toBe(true);
+    });
+
+    it('returns false if id differs', () => {
+        const event2 = { ...baseEvent, id: 'evt_2' };
+        expect(areEventsEqual(baseEvent, event2)).toBe(false);
+    });
+
+    it('returns false if title differs', () => {
+        const event2 = { ...baseEvent, title: 'Meeting 2' };
+        expect(areEventsEqual(baseEvent, event2)).toBe(false);
+    });
+
+    it('returns false if start time differs', () => {
+        const event2 = { ...baseEvent, start: new Date('2024-01-01T10:01:00Z') };
+        expect(areEventsEqual(baseEvent, event2)).toBe(false);
+    });
+
+    it('returns false if end time differs', () => {
+        const event2 = { ...baseEvent, end: new Date('2024-01-01T11:01:00Z') };
+        expect(areEventsEqual(baseEvent, event2)).toBe(false);
+    });
+
+    it('returns false if allDay differs', () => {
+        const event2 = { ...baseEvent, allDay: true };
+        expect(areEventsEqual(baseEvent, event2)).toBe(false);
+    });
+
+    it('returns false if location differs', () => {
+        const event2 = { ...baseEvent, location: 'Room B' };
+        expect(areEventsEqual(baseEvent, event2)).toBe(false);
+    });
+
+    it('returns false if description differs', () => {
+        const event2 = { ...baseEvent, description: 'Updated' };
+        expect(areEventsEqual(baseEvent, event2)).toBe(false);
+    });
+
+    it('returns false if colorId differs', () => {
+        const event2 = { ...baseEvent, colorId: '2' };
+        expect(areEventsEqual(baseEvent, event2)).toBe(false);
+    });
+
+    it('returns false if color differs', () => {
+        const event2 = { ...baseEvent, color: '#00ff00' };
+        expect(areEventsEqual(baseEvent, event2)).toBe(false);
+    });
+});
+
+describe('areEventCardPropsEqual', () => {
+    const baseEvent: AppEvent = {
+        id: '1',
+        title: 'A',
+        start: new Date(),
+        end: new Date()
+    };
+
+    it('returns true if only event prop is deep equal', () => {
+        const props1 = { event: baseEvent, className: 'foo' };
+        const props2 = { event: { ...baseEvent }, className: 'foo' };
+        expect(areEventCardPropsEqual(props1, props2)).toBe(true);
+    });
+
+    it('returns false if className differs', () => {
+        const props1 = { event: baseEvent, className: 'foo' };
+        const props2 = { event: baseEvent, className: 'bar' };
+        expect(areEventCardPropsEqual(props1, props2)).toBe(false);
+    });
+
+    it('ignores onClick changes', () => {
+        const props1 = { event: baseEvent, onClick: () => {} };
+        const props2 = { event: baseEvent, onClick: () => {} };
+        expect(areEventCardPropsEqual(props1, props2)).toBe(true);
+    });
+});

--- a/src/utils/eventUtils.ts
+++ b/src/utils/eventUtils.ts
@@ -1,0 +1,39 @@
+import { AppEvent } from '../types';
+
+/**
+ * deeply compares two AppEvent objects.
+ * Useful for React.memo to avoid re-renders when event objects are recreated but content is identical.
+ */
+export function areEventsEqual(prev: AppEvent, next: AppEvent): boolean {
+    if (prev === next) return true;
+    if (!prev || !next) return false;
+
+    return (
+        prev.id === next.id &&
+        prev.title === next.title &&
+        prev.start.getTime() === next.start.getTime() &&
+        prev.end.getTime() === next.end.getTime() &&
+        prev.allDay === next.allDay &&
+        prev.isHoliday === next.isHoliday &&
+        prev.description === next.description &&
+        prev.location === next.location &&
+        prev.colorId === next.colorId &&
+        prev.color === next.color
+    );
+}
+
+/**
+ * Comparison function for React.memo on components that take an AppEvent.
+ * Ignores function prop changes (onClick, onEventClick) as they are typically stable or
+ * shouldn't trigger re-render if the data hasn't changed.
+ */
+export function areEventCardPropsEqual(
+    prev: { event: AppEvent; className?: string },
+    next: { event: AppEvent; className?: string }
+): boolean {
+    // If className changes, we must re-render
+    if (prev.className !== next.className) return false;
+
+    // Compare event data deeply
+    return areEventsEqual(prev.event, next.event);
+}


### PR DESCRIPTION
Prevents unnecessary re-renders of EventCard components by implementing a custom React.memo comparison function. This optimization significantly reduces the rendering workload when the Dashboard refreshes data (every 5 minutes), as the new event objects are referentially different but deeply equal.

Includes comprehensive unit tests for the equality logic to ensure correctness.

---
*PR created automatically by Jules for task [18263340140851958162](https://jules.google.com/task/18263340140851958162) started by @natanbr*