### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix parameter injection in WeatherService

### DIFF
--- a/electron/weather.ts
+++ b/electron/weather.ts
@@ -19,7 +19,17 @@ interface Station {
 
 export class WeatherService {
 
+    private validateCoordinates(lat: number, lng: number) {
+        if (typeof lat !== 'number' || typeof lng !== 'number') {
+            throw new Error('Invalid coordinates: must be numbers');
+        }
+        if (lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+            throw new Error('Invalid coordinates: out of range');
+        }
+    }
+
     async getWeather(lat: number = SOOKE_LAT, lng: number = SOOKE_LONG): Promise<WeatherData> {
+        this.validateCoordinates(lat, lng);
         const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lng}&current=temperature_2m,weather_code,wind_speed_10m,wind_direction_10m,wind_gusts_10m&hourly=temperature_2m,precipitation_probability,weather_code,wind_speed_10m,wind_direction_10m,wind_gusts_10m&daily=sunrise,sunset,weather_code,temperature_2m_max,temperature_2m_min&timezone=auto&forecast_days=7`;
 
         try {
@@ -59,6 +69,8 @@ export class WeatherService {
     }
 
     async getTides(tideStationCode: string = '07020', currentStationCode: string = '07090', lat: number = SOOKE_LAT, lng: number = SOOKE_LONG): Promise<TideData> {
+        this.validateCoordinates(lat, lng);
+
         // 1. Define Time Range
         const now = new Date();
         const start = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();

--- a/electron/weather_security.test.ts
+++ b/electron/weather_security.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { weatherService } from './weather';
+
+describe('WeatherService Security', () => {
+    const fetchMock = vi.fn();
+
+    beforeEach(() => {
+        global.fetch = fetchMock;
+        fetchMock.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                current: {}, daily: {}, hourly: { time: [] }
+            })
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should validate latitude input to prevent parameter injection', async () => {
+        // Attack payload: injecting extra query parameters
+        // We cast to any to simulate IPC call passing a string where a number is expected
+        const maliciousLat = "50&hourly=sensitive_data" as any;
+
+        // This should throw an error due to input validation
+        await expect(weatherService.getWeather(maliciousLat, -123.0))
+            .rejects.toThrow(/Invalid coordinates/);
+    });
+
+    it('should validate longitude input to prevent parameter injection', async () => {
+        const maliciousLng = "-123&hourly=sensitive_data" as any;
+        await expect(weatherService.getWeather(50.0, maliciousLng))
+            .rejects.toThrow(/Invalid coordinates/);
+    });
+
+    it('should validate coordinates in getTides', async () => {
+        const maliciousLat = "50&hourly=sensitive_data" as any;
+        await expect(weatherService.getTides('07020', '07090', maliciousLat, -123.0))
+            .rejects.toThrow(/Invalid coordinates/);
+    });
+});


### PR DESCRIPTION
**Vulnerability:** The `WeatherService` methods `getWeather` and `getTides` directly interpolated `lat` and `lng` arguments into the Open-Meteo API URL string. Since these arguments can come from Electron IPC messages (which are not type-checked at runtime despite TypeScript signatures), a compromised renderer could inject arbitrary strings to modify the API request.

**Fix:** Introduced a `validateCoordinates` private method that ensures `lat` and `lng` are:
1.  Strictly of type `number`.
2.  Within valid geographical ranges (-90 to 90, -180 to 180).

**Verification:** Added `electron/weather_security.test.ts` which attempts to pass malicious strings (e.g., `"50&hourly=sensitive_data"`) to the service. The test confirms that such attempts now throw an explicit "Invalid coordinates" error instead of being processed. All existing unit tests passed.

---
*PR created automatically by Jules for task [10342861754082097945](https://jules.google.com/task/10342861754082097945) started by @natanbr*