### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix parameter injection & add coordinate validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** OAuth tokens were stored in plaintext in `config.json` via `electron-store`. Additionally, `electron/store.ts` used `fs.writeFileSync` to save user settings to the same file, which would overwrite the entire file and delete the tokens.
 **Learning:** `electron-store` defaults to `config.json` unless named. Manual `fs` usage on the same file can cause data loss and race conditions. Storing refresh tokens in plaintext exposes user sessions to file system attacks.
 **Prevention:** Always use `safeStorage` for sensitive data like tokens. Use named stores (e.g., `new Store({ name: 'auth' })`) for different concerns to isolate data and avoid conflicts.
+
+## 2026-02-16 - [Parameter Injection via Template Literals]
+**Vulnerability:** Weather API URLs were constructed using template literals with user-supplied latitude/longitude inputs, allowing parameter injection if inputs were not validated numbers.
+**Learning:** Even internal APIs that expect numbers can be vulnerable if inputs are strings via IPC (which bypasses compile-time type checks). Template literals do not encode special characters.
+**Prevention:** Always use `URL` and `URLSearchParams` for constructing external API calls. Validate all inputs at the boundary (IPC handler or service method entry).


### PR DESCRIPTION
This PR addresses a potential security vulnerability where invalid or malicious latitude/longitude inputs could be injected into external API calls.

Changes:
1.  **Input Validation**: Implemented strict validation for latitude (-90 to 90) and longitude (-180 to 180) in `WeatherService`. Inputs must be numbers.
2.  **Secure URL Construction**: Replaced template literals with the `URL` and `URLSearchParams` APIs for constructing requests to Open-Meteo. This ensures proper encoding of parameters.
3.  **Testing**: Added `electron/weather_security.test.ts` to verify that invalid inputs are rejected and correct inputs are processed safely.

Verification:
- Run `npm run test:unit electron/weather_security.test.ts` to confirm validation logic.
- Run `npm run test:unit` to ensure no regressions in existing weather functionality.

---
*PR created automatically by Jules for task [16646545929238860216](https://jules.google.com/task/16646545929238860216) started by @natanbr*