### PR TITLE
Fix calendar date stagnation and ensure auto-navigation at midnight

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -11,6 +11,7 @@ import { getWeatherIcon } from '../utils/weatherIcons';
 import { getWeekStartDate, canNavigateToPreviousWeek, isCurrentWeek } from '../utils/weekNavigation';
 import { MARINE_LOCATIONS } from '../utils/marineLocations';
 import { useTheme } from '../hooks/useTheme';
+import { useCurrentDate } from '../hooks/useCurrentDate';
 import { UpdateNotification } from './UpdateNotification';
 
 const DAYS_TO_SHOW = 7;
@@ -39,7 +40,7 @@ export const Dashboard: React.FC = () => {
   // Apply Theme Logic
   useTheme(config, weather);
 
-  const today = useMemo(() => new Date(), []);
+  const today = useCurrentDate();
   const startDate = useMemo(() => getWeekStartDate(today, weekOffset, config.weekStartDay), [today, weekOffset, config.weekStartDay]);
   const days = useMemo(() => Array.from({ length: DAYS_TO_SHOW }, (_, i) => addDays(startDate, i)), [startDate]);
 

--- a/src/hooks/__tests__/useCurrentDate.test.ts
+++ b/src/hooks/__tests__/useCurrentDate.test.ts
@@ -1,0 +1,57 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { useCurrentDate } from '../useCurrentDate';
+import { startOfDay, addDays } from 'date-fns';
+
+describe('useCurrentDate', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('should return the current date initially', () => {
+        const initialDate = new Date(2023, 0, 1, 10, 0, 0); // Jan 1, 2023 10:00:00
+        vi.setSystemTime(initialDate);
+
+        const { result } = renderHook(() => useCurrentDate());
+
+        expect(result.current).toEqual(startOfDay(initialDate));
+    });
+
+    it('should update the date when the day changes', () => {
+        const initialDate = new Date(2023, 0, 1, 23, 59, 0); // Jan 1, 2023 23:59:00
+        vi.setSystemTime(initialDate);
+
+        const { result } = renderHook(() => useCurrentDate());
+
+        expect(result.current).toEqual(startOfDay(initialDate));
+
+        // Advance time by 2 minutes to cross midnight
+        act(() => {
+            vi.advanceTimersByTime(2 * 60 * 1000);
+        });
+
+        const expectedDate = startOfDay(addDays(initialDate, 1)); // Jan 2, 2023 00:00:00
+        expect(result.current).toEqual(expectedDate);
+    });
+
+    it('should not update if the day has not changed', () => {
+        const initialDate = new Date(2023, 0, 1, 10, 0, 0); // Jan 1, 2023 10:00:00
+        vi.setSystemTime(initialDate);
+
+        const { result } = renderHook(() => useCurrentDate());
+
+        const firstRenderDate = result.current;
+
+        // Advance time by 1 hour (still same day)
+        act(() => {
+            vi.advanceTimersByTime(60 * 60 * 1000);
+        });
+
+        // Should still be the same object reference
+        expect(result.current).toBe(firstRenderDate);
+    });
+});

--- a/src/hooks/useCurrentDate.ts
+++ b/src/hooks/useCurrentDate.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react';
+import { startOfDay } from 'date-fns';
+
+/**
+ * A hook that returns the current date, updating automatically when the day changes (at midnight).
+ * It checks for date changes every minute.
+ */
+export function useCurrentDate() {
+    // Initialize with start of today to ensure consistency
+    const [today, setToday] = useState(() => startOfDay(new Date()));
+
+    useEffect(() => {
+        const checkDate = () => {
+            const now = new Date();
+            const currentStartOfDay = startOfDay(now);
+
+            // Compare timestamps to see if the day has changed
+            // We use functional state update to access the current 'today' without adding it to dependencies
+            // preventing unnecessary interval recreations.
+            setToday(prevToday => {
+                if (currentStartOfDay.getTime() !== prevToday.getTime()) {
+                    return currentStartOfDay;
+                }
+                return prevToday;
+            });
+        };
+
+        // Check every minute
+        const interval = setInterval(checkDate, 60 * 1000);
+
+        // Initial check in case the component mounts just before midnight
+        checkDate();
+
+        return () => clearInterval(interval);
+    }, []);
+
+    return today;
+}


### PR DESCRIPTION
This change addresses the issue where the calendar view would remain stuck on the previous day if the application was left open overnight. By replacing the static initialization of `today` with a reactive `useCurrentDate` hook, the application now automatically updates the date reference at midnight, ensuring both the "Today" view and static week views progress correctly to the new day/week without requiring a manual refresh.

---
*PR created automatically by Jules for task [985538841497561859](https://jules.google.com/task/985538841497561859) started by @natanbr*