### PR TITLE
🛡️ Sentinel: [HIGH] Fix concurrent OAuth flows and resource exhaustion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,7 @@
 **Vulnerability:** The main Electron window's `webContents` did not implement a `setWindowOpenHandler` handler, allowing potentially unauthorized opening of new browser windows (`window.open`) from the renderer process.
 **Learning:** By default, Electron permits `window.open` requests, which can open unrestricted secondary windows exposing vulnerabilities if the renderer script is compromised or injected (e.g. bypassing sandboxes, executing malicious scripts).
 **Prevention:** Always implement `setWindowOpenHandler` on `webContents` to return `{ action: 'deny' }` for unneeded scenarios, preventing unauthorized new windows.
+## 2025-05-24 - [Unbounded OAuth Callbacks and DoS]
+**Vulnerability:** The local `http.createServer` used for receiving the OAuth redirect had no concurrency limits or timeout, allowing multiple `startAuth()` calls to spawn indefinite HTTP servers, leading to potential resource exhaustion (DoS) or unexpected behavior.
+**Learning:** Functions creating network servers inside desktop application boundaries must enforce concurrency constraints (e.g., single active flow) and finite lifetimes (timeouts) to prevent accumulating zombie listeners.
+**Prevention:** Always maintain internal state to track ongoing asynchronous flows that allocate system resources (like ports) and implement `setTimeout` to forcibly close them and reject the operation if abandoned.

--- a/electron/auth.ts
+++ b/electron/auth.ts
@@ -20,6 +20,7 @@ const SCOPES = [
 
 export class AuthService {
     private oauth2Client: OAuth2Client;
+    private isAuthInProgress: boolean = false;
 
     constructor() {
         // These will be loaded from env vars or a separate config file
@@ -89,7 +90,12 @@ export class AuthService {
     }
 
     async startAuth(): Promise<void> {
-        return new Promise((resolve, reject) => {
+        if (this.isAuthInProgress) {
+            return Promise.reject(new Error('Authentication is already in progress.'));
+        }
+        this.isAuthInProgress = true;
+
+        const authPromise = new Promise<void>((resolve, reject) => {
             // Generate a secure random state token for CSRF protection
             const state = crypto.randomBytes(32).toString('hex');
             let redirectUri = '';
@@ -162,6 +168,11 @@ export class AuthService {
             });
 
             // Listen on random port (0) and loopback address
+            const timeoutHandle = setTimeout(() => {
+                reject(new Error('Authentication timed out.'));
+                server.close();
+            }, 5 * 60 * 1000); // 5 minutes timeout
+
             server.listen(0, '127.0.0.1', () => {
                 const address = server.address() as AddressInfo;
                 if (address) {
@@ -184,10 +195,18 @@ export class AuthService {
                 }
             });
 
+            server.on('close', () => {
+                clearTimeout(timeoutHandle);
+            });
+
             server.on('error', (err) => {
                 reject(err);
                 server.close();
             });
+        });
+
+        return authPromise.finally(() => {
+            this.isAuthInProgress = false;
         });
     }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Repeated calls to `auth:login` could spawn indefinite, unbounded `http.createServer` instances because there was no concurrency limit or timeout for the OAuth flow. This could lead to local resource exhaustion (DoS) by accumulating zombie servers listening on random ports.
🎯 Impact: An attacker could trigger repeated flows, consuming system resources, or the user could simply abandon multiple windows leaving orphaned servers.
🔧 Fix: Implemented an `isAuthInProgress` lock to prevent multiple concurrent flows and added a strict 5-minute timeout using `setTimeout` to forcibly reject abandoned flows and clear out system resources.
✅ Verification: Ran `npm run lint` and `npm run test:unit`. Also verified the exact lock and timeout implementation is safe and leak-proof in a code review.

---
*PR created automatically by Jules for task [1019608029681035310](https://jules.google.com/task/1019608029681035310) started by @natanbr*