### PR TITLE
⚡ Bolt: Optimize MonthlyView Grid Repaint using React.memo

### DIFF
--- a/src/components/MonthlyView.tsx
+++ b/src/components/MonthlyView.tsx
@@ -11,6 +11,8 @@ interface MonthlyViewProps {
   referenceDate: Date; // The month we are currently viewing
 }
 
+const EMPTY_EVENTS: AppEvent[] = [];
+
 export const MonthlyView: React.FC<MonthlyViewProps> = ({ days, events, onEventClick, currentDate, referenceDate }) => {
     // Day names header
     const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -52,58 +54,89 @@ export const MonthlyView: React.FC<MonthlyViewProps> = ({ days, events, onEventC
             <div className="flex-1 grid grid-cols-7 grid-rows-5 divide-x divide-y divide-zinc-200 dark:divide-zinc-800 border-b border-zinc-200 dark:border-zinc-800">
                 {days.map((day) => {
                     const dateStr = `${day.getFullYear()}-${day.getMonth()}-${day.getDate()}`;
-                    const dayEvents = eventsByDayMap.get(dateStr) || [];
+                    const dayEvents = eventsByDayMap.get(dateStr) || EMPTY_EVENTS;
                     const isToday = isSameDay(day, currentDate);
                     const isCurrentMonth = isSameMonth(day, referenceDate);
 
                     return (
-                        <div
+                        <MonthlyDayCell
                             key={day.toISOString()}
-                            data-testid={`month-day-${day.toISOString().slice(0, 10)}`}
-                            className={`flex flex-col p-2 min-h-0 overflow-hidden transition-colors ${!isCurrentMonth ? 'bg-zinc-50/30 dark:bg-zinc-900/10' : ''} ${isToday ? 'bg-family-cyan/5 dark:bg-family-cyan/10' : ''}`}
-                        >
-                            <div className="flex justify-end mb-2">
-                                <span className={`text-sm font-black ${
-                                    isToday
-                                        ? 'bg-family-cyan text-white rounded-full w-7 h-7 flex items-center justify-center shadow-lg shadow-family-cyan/30'
-                                        : isCurrentMonth
-                                            ? 'text-zinc-800 dark:text-zinc-200'
-                                            : 'text-zinc-300 dark:text-zinc-700'
-                                }`}>
-                                    {format(day, 'd')}
-                                </span>
-                            </div>
-
-                            <div className="flex-1 overflow-y-auto space-y-1.5 no-scrollbar">
-                                {dayEvents.map(event => {
-                                    const { style, className } = getEventColorStyles(event.title, event.description, event.colorId, event.color);
-
-                                    // Use the background color for the bullet point
-                                    // If style.backgroundColor is missing (Tailwind class used), we might need a fallback or parse it
-                                    // But usually getEventColorStyles returns style for custom colors.
-                                    // For Google colors, it returns className with bg-xxx.
-
-                                    return (
-                                        <button
-                                            key={event.id}
-                                            onClick={() => onEventClick(event)}
-                                            className="w-full flex items-center gap-2 group text-left outline-none"
-                                        >
-                                            <div
-                                                className={`w-2.5 h-2.5 rounded-full shrink-0 shadow-sm group-hover:scale-125 transition-transform ${!style?.backgroundColor ? className.split(' ')[0] : ''}`}
-                                                style={style?.backgroundColor ? { backgroundColor: style.backgroundColor } : {}}
-                                            />
-                                            <span className="text-[11px] font-bold truncate text-zinc-600 dark:text-zinc-400 group-hover:text-zinc-900 dark:group-hover:text-zinc-100 transition-colors uppercase tracking-tight">
-                                                {event.title}
-                                            </span>
-                                        </button>
-                                    );
-                                })}
-                            </div>
-                        </div>
+                            day={day}
+                            dayEvents={dayEvents}
+                            isToday={isToday}
+                            isCurrentMonth={isCurrentMonth}
+                            onEventClick={onEventClick}
+                        />
                     );
                 })}
             </div>
         </div>
     );
 };
+
+interface MonthlyDayCellProps {
+    day: Date;
+    dayEvents: AppEvent[];
+    isToday: boolean;
+    isCurrentMonth: boolean;
+    onEventClick: (event: AppEvent) => void;
+}
+
+// ⚡ Bolt Performance: Custom comparison for Date to make React.memo effective
+const areDayPropsEqual = (prev: MonthlyDayCellProps, next: MonthlyDayCellProps) => {
+    return (
+        prev.day.getTime() === next.day.getTime() &&
+        prev.dayEvents === next.dayEvents &&
+        prev.isToday === next.isToday &&
+        prev.isCurrentMonth === next.isCurrentMonth &&
+        prev.onEventClick === next.onEventClick
+    );
+};
+
+// ⚡ Bolt Performance: Memoize grid cells to prevent full-list re-renders when parent state (e.g. current time tick) changes
+const MonthlyDayCell: React.FC<MonthlyDayCellProps> = React.memo(({ day, dayEvents, isToday, isCurrentMonth, onEventClick }) => {
+    // ⚡ Bolt Performance: Cache expensive getEventColorStyles mapping
+    const renderedEvents = useMemo(() => {
+        return dayEvents.map(event => {
+            const { style, className } = getEventColorStyles(event.title, event.description, event.colorId, event.color);
+            return { event, style, className };
+        });
+    }, [dayEvents]);
+
+    return (
+        <div
+            data-testid={`month-day-${day.toISOString().slice(0, 10)}`}
+            className={`flex flex-col p-2 min-h-0 overflow-hidden transition-colors ${!isCurrentMonth ? 'bg-zinc-50/30 dark:bg-zinc-900/10' : ''} ${isToday ? 'bg-family-cyan/5 dark:bg-family-cyan/10' : ''}`}
+        >
+            <div className="flex justify-end mb-2">
+                <span className={`text-sm font-black ${
+                    isToday
+                        ? 'bg-family-cyan text-white rounded-full w-7 h-7 flex items-center justify-center shadow-lg shadow-family-cyan/30'
+                        : isCurrentMonth
+                            ? 'text-zinc-800 dark:text-zinc-200'
+                            : 'text-zinc-300 dark:text-zinc-700'
+                }`}>
+                    {format(day, 'd')}
+                </span>
+            </div>
+
+            <div className="flex-1 overflow-y-auto space-y-1.5 no-scrollbar">
+                {renderedEvents.map(({ event, style, className }) => (
+                    <button
+                        key={event.id}
+                        onClick={() => onEventClick(event)}
+                        className="w-full flex items-center gap-2 group text-left outline-none"
+                    >
+                        <div
+                            className={`w-2.5 h-2.5 rounded-full shrink-0 shadow-sm group-hover:scale-125 transition-transform ${!style?.backgroundColor ? className.split(' ')[0] : ''}`}
+                            style={style?.backgroundColor ? { backgroundColor: style.backgroundColor } : {}}
+                        />
+                        <span className="text-[11px] font-bold truncate text-zinc-600 dark:text-zinc-400 group-hover:text-zinc-900 dark:group-hover:text-zinc-100 transition-colors uppercase tracking-tight">
+                            {event.title}
+                        </span>
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+}, areDayPropsEqual);


### PR DESCRIPTION
💡 What: Extracted `MonthlyDayCell` into its own `React.memo` component within `MonthlyView` and added a custom deep equality comparison function (`areDayPropsEqual`) using `.getTime()`. Also extracted `EMPTY_EVENTS` to the module level and memoized the inner color rendering computations using `useMemo`.

🎯 Why: The calendar cell re-renders were extremely expensive because the parent passes dynamically instantiated `Date` objects, defeating standard shallow `React.memo` reference equality. Additionally, creating a new `[]` fallback via `|| []` caused a new reference allocation for every empty day, also forcing re-renders. Without this fix, checking the live clock or scrolling weeks would rebuild 35 days of DOM events simultaneously.

📊 Impact: The 35 grid cells in the `MonthlyView` now only re-render if their exact underlying date or associated array of events actually change. Avoids `O(35 * N)` operations related to Tailwind class parsing and DOM building every time the top-level app updates (like during a clock tick or resize event).

🔬 Measurement: Verify with React DevTools profiler by switching months and opening/closing side panels: previously, the entire grid lit up with update traces; now, only newly appearing cell bounds will trigger renders.

---
*PR created automatically by Jules for task [8415515177330425534](https://jules.google.com/task/8415515177330425534) started by @natanbr*