### PR TITLE
📐 Architect: [Refactor/Health improvement] Split mcReducer

### DIFF
--- a/.jules/architect-journal.md
+++ b/.jules/architect-journal.md
@@ -30,3 +30,7 @@
 **Anti-Pattern: Hardcoded Colors Bypassing Design System.** The game introduces a standalone `snake.css` with raw hex values instead of utilizing Tailwind or `gcal-simplified` design tokens, violating the styling invariants.
 **Anti-Pattern: Unused Variables Breaking CI.** Leaving variables like `_livesRemaining` defined but unused in `QuizOverlay.tsx` triggers `--max-warnings 0` ESLint failures. Strict lint hygiene must be maintained before merging.
 **Regression Risk: Missing Coverage.** The core game engine (`useSnakeGame.ts`) and React overlays were committed without corresponding Vitest unit tests, while only `additionQuiz.test.ts` was implemented.
+## 2024-05-10 - Split God Reducer
+
+**Learning:** `src/mission-control/store/mcReducer.ts` had grown into a God file of >600 lines containing logic for multiple domains (economy, missions, settings, logs, privileges, security). We successfully split this into domain-specific reducers (`economyReducer.ts`, `missionReducer.ts`, etc.) in a `reducers/` subdirectory while keeping the `MCState` intact and the root `mcReducer.ts` file purely for delegation and composition (`syncCreamTask`).
+**Action:** When a reducer file grows too large and handles mixed concerns, actively split the `switch` cases into distinct domain-specific functions that accept and return the full state (or domain sub-states) to reduce token usage and improve maintainability, following the Single Responsibility Principle.

--- a/src/mission-control/store/mcReducer.ts
+++ b/src/mission-control/store/mcReducer.ts
@@ -18,6 +18,14 @@ import type {
 } from '../types';
 import { DEFAULT_SETTINGS } from '../types';
 
+import { reduceEconomy } from './reducers/economyReducer';
+import { reduceMissions } from './reducers/missionReducer';
+import { reduceResponsibilities } from './reducers/responsibilityReducer';
+import { reduceSettings } from './reducers/settingsReducer';
+import { reduceLogs } from './reducers/logReducer';
+import { reducePrivileges } from './reducers/privilegeReducer';
+import { reduceSecurity } from './reducers/securityReducer';
+
 // ---- Default State ----
 
 const defaultCases: DisplayCase[] = [
@@ -112,451 +120,54 @@ export const initialState: MCState = {
 
 function _mcReducer(state: MCState, action: MCAction): MCState {
     switch (action.type) {
+        // Economy actions
         case 'ADD_TOKEN':
-            return { ...state, bankCount: state.bankCount + 1 };
-
         case 'ADD_TOKENS':
-            return { ...state, bankCount: state.bankCount + action.amount };
-
         case 'REMOVE_TOKEN':
-            return { ...state, bankCount: Math.max(0, state.bankCount - 1) };
-
-        case 'SELECT_CASE': {
-            const isQuickGame = action.reward === 'quick-game';
-            if (isQuickGame && state.gameTokens <= 0) return state;
-
-            return {
-                ...state,
-                gameTokens: isQuickGame ? state.gameTokens - 1 : state.gameTokens,
-                cases: state.cases.map(c =>
-                    c.id === action.caseId
-                        ? { ...c, status: 'active', reward: action.reward, targetCount: action.targetCount }
-                        : c,
-                ),
-            };
-        }
-
-        case 'DEPOSIT_TO_CASE': {
-            const amount = Math.min(action.amount, state.bankCount);
-            return {
-                ...state,
-                bankCount: state.bankCount - amount,
-                cases: state.cases.map(c =>
-                    c.id === action.caseId
-                        ? { ...c, tokenCount: c.tokenCount + amount }
-                        : c,
-                ),
-            };
-        }
-
-        case 'MOVE_TOKEN': {
-            // Source Validation
-            if (action.from === 'bank' && state.bankCount <= 0) return state;
-            if (typeof action.from === 'number') {
-                const sourceCase = state.cases.find(c => c.id === action.from);
-                if (!sourceCase || sourceCase.tokenCount <= 0) return state;
-            }
-
-            // Target Validation
-            if (typeof action.to === 'number') {
-                const targetCase = state.cases.find(c => c.id === action.to);
-                if (!targetCase || targetCase.status !== 'active') return state;
-            }
-
-            let newBankCount = state.bankCount;
-            let newCases = state.cases;
-
-            // Decrement source
-            if (action.from === 'bank') {
-                newBankCount -= 1;
-            } else {
-                newCases = newCases.map(c => c.id === action.from ? { ...c, tokenCount: Math.max(0, c.tokenCount - 1) } : c);
-            }
-
-            // Increment target
-            if (action.to === 'bank') {
-                newBankCount += 1;
-            } else {
-                newCases = newCases.map(c => c.id === action.to ? { ...c, tokenCount: c.tokenCount + 1 } : c);
-            }
-
-            return {
-                ...state,
-                bankCount: newBankCount,
-                cases: newCases,
-            };
-        }
-
-        case 'VACUUM_TO_CASE': {
-            if (state.bankCount === 0) return state;
-            const vacuumTarget = state.cases.find(c => c.id === action.caseId);
-            if (!vacuumTarget) return state;
-            const canAdd = Math.min(state.bankCount, vacuumTarget.targetCount - vacuumTarget.tokenCount);
-            if (canAdd <= 0) return state;
-            return {
-                ...state,
-                bankCount: state.bankCount - canAdd,
-                cases: state.cases.map(c =>
-                    c.id === action.caseId
-                        ? { ...c, tokenCount: c.tokenCount + canAdd }
-                        : c,
-                ),
-            };
-        }
-
-        case 'REFUND_CASE': {
-            const targetCase = state.cases.find(c => c.id === action.caseId);
-            if (!targetCase) return state;
-            const isQuickGame = targetCase.reward === 'quick-game';
-            return {
-                ...state,
-                bankCount: state.bankCount + targetCase.tokenCount,
-                gameTokens: isQuickGame ? Math.min(5, state.gameTokens + 1) : state.gameTokens,
-                cases: state.cases.map(c =>
-                    c.id === action.caseId
-                        ? { ...c, status: 'empty', reward: null, tokenCount: 0 }
-                        : c,
-                ),
-            };
-        }
-
-        case 'SET_PRIVILEGE_STATUS':
-            return {
-                ...state,
-                privileges: state.privileges.map(p =>
-                    p.id === action.cardId
-                        ? { ...p, status: action.status, suspendedUntil: action.suspendedUntil }
-                        : p,
-                ),
-            };
-
-        case 'COMPLETE_TASK': {
-            const nextState = { ...state };
-            if (action.taskId === 'cream') {
-                const schedule = state.settings.creamTaskSchedule ?? 'evening';
-                const dec = schedule === 'both' ? 0.5 : 1;
-                nextState.creamTaskDaysLeft = Math.max(0, state.creamTaskDaysLeft - dec);
-            }
-            nextState.missions = nextState.missions.map(m =>
-                m.phase === action.missionPhase
-                    ? {
-                        ...m,
-                        tasks: m.tasks.map(t =>
-                            t.id === action.taskId ? { ...t, completed: true } : t,
-                        ),
-                    }
-                    : m,
-            );
-            // Auto-disable if today was the last day
-            if (action.taskId === 'cream' && nextState.creamTaskDaysLeft === 0) {
-                 nextState.settings = { ...nextState.settings, creamTaskEnabled: false };
-            }
-            return nextState;
-        }
-
-        case 'LOCK_TASK':
-            return {
-                ...state,
-                missions: state.missions.map(m =>
-                    m.phase === action.missionPhase
-                        ? {
-                            ...m,
-                            tasks: m.tasks.map(t =>
-                                t.id === action.taskId ? { ...t, locked: true } : t,
-                            ),
-                        }
-                        : m,
-                ),
-            };
-
-        case 'SET_ACTIVE_MISSION': {
-            // Timer expired — deactivate. Tasks are intentionally left as-is
-            // (they're reset when the mission re-triggers via SET_ACTIVE_MISSION).
-            if (action.phase === 'none') {
-                return {
-                    ...state,
-                    activeMission: 'none',
-                    missions: state.missions.map(m => ({
-                        ...m,
-                        active: false,
-                        durationMins: undefined,
-                    })),
-                };
-            }
-
-            // Only one mission at a time — if one is already running, ignore the new trigger
-            if (state.activeMission !== 'none') {
-                return state;
-            }
-
-            const now = new Date().toISOString();
-            return {
-                ...state,
-                activeMission: action.phase,
-                missions: state.missions.map(m => {
-                    if (m.phase !== action.phase) return { ...m, active: false };
-                    // Every trigger is a fresh start: new timer, reset checklist.
-                    const [sh, sm] = m.startsAt.split(':').map(Number);
-                    const [eh, em] = m.endsAt.split(':').map(Number);
-                    const durationMins = (eh * 60 + em) - (sh * 60 + sm);
-                    return {
-                        ...m,
-                        active: true,
-                        startedAt: now,
-                        durationMins: Math.max(0, durationMins), // no minimum — allows sub-minute test durations
-                        tasks: m.tasks.map(t => ({ ...t, completed: false, locked: false })),
-                    };
-                }),
-            };
-        }
-
-        // Reset task progress only — mission stays active, timer keeps running.
-        // Does NOT affect startedAt/durationMins/activeMission.
-        case 'RESET_MISSION':
-            return {
-                ...state,
-                missions: state.missions.map(m =>
-                    m.phase === action.missionPhase
-                        ? { ...m, active: true, loggedTimeoutAt: undefined, tasks: m.tasks.map(t => ({ ...t, completed: false, locked: false })) }
-                        : m
-                )
-            };
-
-        // Full reset — tasks AND timer restart from scratch.
-        // Mission stays active with a fresh startedAt + recalculated durationMins.
-        case 'RESET_MISSION_WITH_TIMER': {
-            const now = new Date().toISOString();
-            return {
-                ...state,
-                missions: state.missions.map(m => {
-                    if (m.phase !== action.missionPhase) return m;
-                    const [sh, sm] = m.startsAt.split(':').map(Number);
-                    const [eh, em] = m.endsAt.split(':').map(Number);
-                    let durationMins = (eh * 60 + em) - (sh * 60 + sm);
-                    if (durationMins < 0) durationMins += 24 * 60; // overnight wrap
-                    return {
-                        ...m,
-                        active: true,
-                        startedAt: now,
-                        durationMins,
-                        loggedTimeoutAt: undefined,
-                        tasks: m.tasks.map(t => ({ ...t, completed: false, locked: false })),
-                    };
-                }),
-            };
-        }
-
-        case 'CANCEL_MISSION':
-            return {
-                ...state,
-                activeMission: 'none',
-                missions: state.missions.map(m =>
-                    m.phase === action.missionPhase
-                        ? { ...m, startedAt: undefined, active: false, loggedTimeoutAt: undefined, tasks: m.tasks.map(t => ({ ...t, completed: false, locked: false })) }
-                        : m
-                )
-            };
-
-        case 'COMPLETE_MISSION_ROUTINE':
-            return {
-                ...state,
-                activeMission: 'none',
-                bankCount: state.bankCount + action.bonusTokens,
-                missions: state.missions.map(m =>
-                    m.phase === action.missionPhase
-                        ? { ...m, startedAt: undefined, active: false, loggedTimeoutAt: undefined, tasks: m.tasks.map(t => ({ ...t, completed: false, locked: false })) }
-                        : m
-                )
-            };
-
-        case 'MARK_MISSION_TIMEOUT':
-            return {
-                ...state,
-                missions: state.missions.map(m =>
-                    m.phase === action.missionPhase
-                        ? { ...m, loggedTimeoutAt: new Date().toISOString() }
-                        : m
-                )
-            };
-
-        case 'ADJUST_MISSION_END': {
-            return {
-                ...state,
-                missions: state.missions.map(m => {
-                    if (m.phase !== action.missionPhase) return m;
-                    // Adjust durationMins if mission already started; otherwise adjust endsAt HH:MM
-                    if (m.startedAt && m.durationMins != null) {
-                        return { ...m, durationMins: Math.max(1, m.durationMins + action.deltaMinutes) };
-                    }
-                    const [hh, mm] = m.endsAt.split(':').map(Number);
-                    const totalMins = Math.max(0, Math.min(23 * 60 + 59, hh * 60 + mm + action.deltaMinutes));
-                    const newH = String(Math.floor(totalMins / 60)).padStart(2, '0');
-                    const newM = String(totalMins % 60).padStart(2, '0');
-                    return { ...m, endsAt: `${newH}:${newM}` };
-                }),
-            };
-        }
-
-        case 'CONSUME_CASE': {
-            // Permanently remove tokens from case (reward redeemed) — NO bank refund
-            return {
-                ...state,
-                cases: state.cases.map(c =>
-                    c.id === action.caseId
-                        ? { ...c, status: 'empty' as const, reward: null, tokenCount: 0 }
-                        : c,
-                ),
-            };
-        }
-
-        case 'SET_SETTINGS': {
-            const nextSettings = { ...state.settings, ...action.settings };
-            let nextDaysLeft = state.creamTaskDaysLeft;
-            
-            if (action.settings.creamTaskEnabled && !state.settings.creamTaskEnabled) {
-                // Just enabled — start fresh
-                nextDaysLeft = nextSettings.creamTaskDaysTarget;
-            } else if (action.settings.creamTaskDaysTarget !== undefined && action.settings.creamTaskDaysTarget !== state.settings.creamTaskDaysTarget) {
-                 // Target changed, reset current progress
-                 nextDaysLeft = action.settings.creamTaskDaysTarget;
-            }
-
-            // If the start time of the currently-active mission changes, we must also
-            // deactivate it — otherwise durationMins is wiped but active stays true,
-            // making the expiry check `durationMins != null` permanently false (hung mission).
-            const mornTimeChanged =
-                (action.settings.morningStartsAt ?? state.settings.morningStartsAt) !== state.settings.morningStartsAt;
-            const evenTimeChanged =
-                (action.settings.eveningStartsAt ?? state.settings.eveningStartsAt) !== state.settings.eveningStartsAt;
-            const activeIsBeingRescheduled =
-                (state.activeMission === 'morning' && mornTimeChanged) ||
-                (state.activeMission === 'evening' && evenTimeChanged);
-
-            return {
-                ...state,
-                settings: nextSettings,
-                creamTaskDaysLeft: nextDaysLeft,
-                // Deactivate root if the running mission's start time was changed
-                ...(activeIsBeingRescheduled ? { activeMission: 'none' as const } : {}),
-                // Live-update mission startsAt/endsAt from settings so scheduler picks them up.
-                // If the start time changes, clear startedAt, durationMins, and active
-                // so the scheduler can re-trigger at the new time without getting stuck.
-                missions: state.missions.map(m => {
-                    if (m.phase === 'morning') {
-                        const dur = action.settings.morningDurationMins ?? state.settings.morningDurationMins;
-                        const start = action.settings.morningStartsAt ?? state.settings.morningStartsAt;
-                        const [h, min] = start.split(':').map(Number);
-                        const endTotal = h * 60 + min + dur;
-                        const endsAt = `${String(Math.floor(endTotal / 60)).padStart(2, '0')}:${String(endTotal % 60).padStart(2, '0')}`;
-                        return {
-                            ...m,
-                            startsAt: start,
-                            endsAt,
-                            ...(mornTimeChanged ? { startedAt: undefined, durationMins: undefined, active: false } : {}),
-                        };
-                    }
-                    if (m.phase === 'evening') {
-                        const dur = action.settings.eveningDurationMins ?? state.settings.eveningDurationMins;
-                        const start = action.settings.eveningStartsAt ?? state.settings.eveningStartsAt;
-                        const [h, min] = start.split(':').map(Number);
-                        const endTotal = h * 60 + min + dur;
-                        const endsAt = `${String(Math.floor(endTotal / 60)).padStart(2, '0')}:${String(endTotal % 60).padStart(2, '0')}`;
-                        return {
-                            ...m,
-                            startsAt: start,
-                            endsAt,
-                            ...(evenTimeChanged ? { startedAt: undefined, durationMins: undefined, active: false } : {}),
-                        };
-                    }
-                    return m;
-                }),
-            };
-        }
-
-        case 'ADD_RESPONSIBILITY_POINT': {
-            const now = new Date().toISOString();
-            return {
-                ...state,
-                responsibilities: state.responsibilities.map(r => {
-                    if (r.id !== action.taskId) return r;
-                    if (r.completedAt) return r; // already complete — ignore
-                    const newPoints = r.pointsEarned + 1;
-                    const isComplete = newPoints >= r.pointsRequired;
-                    return {
-                        ...r,
-                        pointsEarned: newPoints,
-                        completedAt: isComplete ? now : null,
-                    };
-                }),
-            };
-        }
-
-        case 'RESET_RESPONSIBILITY': {
-            const addedBank = action.claimTokens ? state.bankCount + action.claimTokens : state.bankCount;
-            return {
-                ...state,
-                bankCount: addedBank,
-                responsibilities: state.responsibilities.map(r =>
-                    r.id === action.taskId
-                        ? { ...r, pointsEarned: 0, completedAt: null }
-                        : r
-                )
-            };
-        }
-
-        case 'ADD_LOG': {
-            const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
-            const nowTime = new Date().getTime();
-            
-            // 1. Add new log to the front
-            // 2. Filter out anything older than 7 days based on timestamp
-            const filteredLogs = [action.log, ...(state.activityLogs || [])].filter(log => {
-                const logTime = new Date(log.timestamp).getTime();
-                return (nowTime - logTime) <= SEVEN_DAYS_MS;
-            });
-
-            return {
-                ...state,
-                activityLogs: filteredLogs
-            };
-        }
-
-        case 'CHEAT_ATTEMPT':
-            return {
-                ...state,
-                hasUnreviewedCheatAttempt: true,
-            };
-
-        case 'CLEAR_CHEAT_FLAG':
-            return {
-                ...state,
-                hasUnreviewedCheatAttempt: false,
-            };
-
-        case 'GRANT_GAME_TOKEN': {
-            const todayStr = new Date().toISOString().slice(0, 10);
-            if (!action.force && state.gameTokensLastGrantedDate === todayStr) return state;
-            
-            const totalWealth = state.bankCount + state.cases.reduce((sum, c) => sum + c.tokenCount, 0);
-            if (totalWealth < 10 && !action.force) return state;
-            if (state.gameTokens >= 5) return state;
-            return {
-                ...state,
-                gameTokens: Math.min(5, state.gameTokens + 1),
-                gameTokensLastGrantedDate: action.force ? state.gameTokensLastGrantedDate : todayStr,
-            };
-        }
-
+        case 'SELECT_CASE':
+        case 'DEPOSIT_TO_CASE':
+        case 'MOVE_TOKEN':
+        case 'VACUUM_TO_CASE':
+        case 'REFUND_CASE':
+        case 'CONSUME_CASE':
+        case 'GRANT_GAME_TOKEN':
         case 'CONSUME_GAME_TOKEN':
-            if (state.gameTokens <= 0) return state;
-            return { ...state, gameTokens: state.gameTokens - 1 };
-
         case 'RESET_GAME_TOKENS':
-            return {
-                ...state,
-                gameTokens: 0,
-                gameTokensLastGrantedDate: null,
-            };
+            return reduceEconomy(state, action);
+
+        // Mission actions
+        case 'COMPLETE_TASK':
+        case 'LOCK_TASK':
+        case 'SET_ACTIVE_MISSION':
+        case 'RESET_MISSION':
+        case 'RESET_MISSION_WITH_TIMER':
+        case 'CANCEL_MISSION':
+        case 'COMPLETE_MISSION_ROUTINE':
+        case 'MARK_MISSION_TIMEOUT':
+        case 'ADJUST_MISSION_END':
+            return reduceMissions(state, action);
+
+        // Responsibility actions
+        case 'ADD_RESPONSIBILITY_POINT':
+        case 'RESET_RESPONSIBILITY':
+            return reduceResponsibilities(state, action);
+
+        // Settings actions
+        case 'SET_SETTINGS':
+            return reduceSettings(state, action);
+
+        // Log actions
+        case 'ADD_LOG':
+            return reduceLogs(state, action);
+
+        // Privilege actions
+        case 'SET_PRIVILEGE_STATUS':
+            return reducePrivileges(state, action);
+
+        // Security actions
+        case 'CHEAT_ATTEMPT':
+        case 'CLEAR_CHEAT_FLAG':
+            return reduceSecurity(state, action);
 
         default:
             return state;

--- a/src/mission-control/store/reducers/economyReducer.ts
+++ b/src/mission-control/store/reducers/economyReducer.ts
@@ -1,0 +1,153 @@
+import { MCState, MCAction } from '../../types';
+
+export function reduceEconomy(state: MCState, action: MCAction): MCState {
+    switch (action.type) {
+        case 'ADD_TOKEN':
+            return { ...state, bankCount: state.bankCount + 1 };
+
+        case 'ADD_TOKENS':
+            return { ...state, bankCount: state.bankCount + action.amount };
+
+        case 'REMOVE_TOKEN':
+            return { ...state, bankCount: Math.max(0, state.bankCount - 1) };
+
+        case 'SELECT_CASE': {
+            const isQuickGame = action.reward === 'quick-game';
+            if (isQuickGame && state.gameTokens <= 0) return state;
+
+            return {
+                ...state,
+                gameTokens: isQuickGame ? state.gameTokens - 1 : state.gameTokens,
+                cases: state.cases.map(c =>
+                    c.id === action.caseId
+                        ? { ...c, status: 'active', reward: action.reward, targetCount: action.targetCount }
+                        : c,
+                ),
+            };
+        }
+
+        case 'DEPOSIT_TO_CASE': {
+            const amount = Math.min(action.amount, state.bankCount);
+            return {
+                ...state,
+                bankCount: state.bankCount - amount,
+                cases: state.cases.map(c =>
+                    c.id === action.caseId
+                        ? { ...c, tokenCount: c.tokenCount + amount }
+                        : c,
+                ),
+            };
+        }
+
+        case 'MOVE_TOKEN': {
+            // Source Validation
+            if (action.from === 'bank' && state.bankCount <= 0) return state;
+            if (typeof action.from === 'number') {
+                const sourceCase = state.cases.find(c => c.id === action.from);
+                if (!sourceCase || sourceCase.tokenCount <= 0) return state;
+            }
+
+            // Target Validation
+            if (typeof action.to === 'number') {
+                const targetCase = state.cases.find(c => c.id === action.to);
+                if (!targetCase || targetCase.status !== 'active') return state;
+            }
+
+            let newBankCount = state.bankCount;
+            let newCases = state.cases;
+
+            // Decrement source
+            if (action.from === 'bank') {
+                newBankCount -= 1;
+            } else {
+                newCases = newCases.map(c => c.id === action.from ? { ...c, tokenCount: Math.max(0, c.tokenCount - 1) } : c);
+            }
+
+            // Increment target
+            if (action.to === 'bank') {
+                newBankCount += 1;
+            } else {
+                newCases = newCases.map(c => c.id === action.to ? { ...c, tokenCount: c.tokenCount + 1 } : c);
+            }
+
+            return {
+                ...state,
+                bankCount: newBankCount,
+                cases: newCases,
+            };
+        }
+
+        case 'VACUUM_TO_CASE': {
+            if (state.bankCount === 0) return state;
+            const vacuumTarget = state.cases.find(c => c.id === action.caseId);
+            if (!vacuumTarget) return state;
+            const canAdd = Math.min(state.bankCount, vacuumTarget.targetCount - vacuumTarget.tokenCount);
+            if (canAdd <= 0) return state;
+            return {
+                ...state,
+                bankCount: state.bankCount - canAdd,
+                cases: state.cases.map(c =>
+                    c.id === action.caseId
+                        ? { ...c, tokenCount: c.tokenCount + canAdd }
+                        : c,
+                ),
+            };
+        }
+
+        case 'REFUND_CASE': {
+            const targetCase = state.cases.find(c => c.id === action.caseId);
+            if (!targetCase) return state;
+            const isQuickGame = targetCase.reward === 'quick-game';
+            return {
+                ...state,
+                bankCount: state.bankCount + targetCase.tokenCount,
+                gameTokens: isQuickGame ? Math.min(5, state.gameTokens + 1) : state.gameTokens,
+                cases: state.cases.map(c =>
+                    c.id === action.caseId
+                        ? { ...c, status: 'empty', reward: null, tokenCount: 0 }
+                        : c,
+                ),
+            };
+        }
+
+        case 'CONSUME_CASE': {
+            // Permanently remove tokens from case (reward redeemed) — NO bank refund
+            return {
+                ...state,
+                cases: state.cases.map(c =>
+                    c.id === action.caseId
+                        ? { ...c, status: 'empty' as const, reward: null, tokenCount: 0 }
+                        : c,
+                ),
+            };
+        }
+
+        case 'GRANT_GAME_TOKEN': {
+            const todayStr = new Date().toISOString().slice(0, 10);
+            if (!action.force && state.gameTokensLastGrantedDate === todayStr) return state;
+
+            const totalWealth = state.bankCount + state.cases.reduce((sum, c) => sum + c.tokenCount, 0);
+            if (totalWealth < 10 && !action.force) return state;
+            if (state.gameTokens >= 5) return state;
+            return {
+                ...state,
+                gameTokens: Math.min(5, state.gameTokens + 1),
+                gameTokensLastGrantedDate: action.force ? state.gameTokensLastGrantedDate : todayStr,
+            };
+        }
+
+        case 'CONSUME_GAME_TOKEN':
+            if (state.gameTokens <= 0) return state;
+            return { ...state, gameTokens: state.gameTokens - 1 };
+
+        case 'RESET_GAME_TOKENS':
+            return {
+                ...state,
+                gameTokens: 0,
+                gameTokensLastGrantedDate: null,
+            };
+
+        default:
+            return state;
+    }
+}

--- a/src/mission-control/store/reducers/logReducer.ts
+++ b/src/mission-control/store/reducers/logReducer.ts
@@ -1,0 +1,25 @@
+import { MCState, MCAction } from '../../types';
+
+export function reduceLogs(state: MCState, action: MCAction): MCState {
+    switch (action.type) {
+        case 'ADD_LOG': {
+            const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+            const nowTime = new Date().getTime();
+
+            // 1. Add new log to the front
+            // 2. Filter out anything older than 7 days based on timestamp
+            const filteredLogs = [action.log, ...(state.activityLogs || [])].filter(log => {
+                const logTime = new Date(log.timestamp).getTime();
+                return (nowTime - logTime) <= SEVEN_DAYS_MS;
+            });
+
+            return {
+                ...state,
+                activityLogs: filteredLogs
+            };
+        }
+
+        default:
+            return state;
+    }
+}

--- a/src/mission-control/store/reducers/missionReducer.ts
+++ b/src/mission-control/store/reducers/missionReducer.ts
@@ -1,0 +1,175 @@
+import { MCState, MCAction } from '../../types';
+
+export function reduceMissions(state: MCState, action: MCAction): MCState {
+    switch (action.type) {
+        case 'COMPLETE_TASK': {
+            const nextState = { ...state };
+            if (action.taskId === 'cream') {
+                const schedule = state.settings.creamTaskSchedule ?? 'evening';
+                const dec = schedule === 'both' ? 0.5 : 1;
+                nextState.creamTaskDaysLeft = Math.max(0, state.creamTaskDaysLeft - dec);
+            }
+            nextState.missions = nextState.missions.map(m =>
+                m.phase === action.missionPhase
+                    ? {
+                        ...m,
+                        tasks: m.tasks.map(t =>
+                            t.id === action.taskId ? { ...t, completed: true } : t,
+                        ),
+                    }
+                    : m,
+            );
+            // Auto-disable if today was the last day
+            if (action.taskId === 'cream' && nextState.creamTaskDaysLeft === 0) {
+                 nextState.settings = { ...nextState.settings, creamTaskEnabled: false };
+            }
+            return nextState;
+        }
+
+        case 'LOCK_TASK':
+            return {
+                ...state,
+                missions: state.missions.map(m =>
+                    m.phase === action.missionPhase
+                        ? {
+                            ...m,
+                            tasks: m.tasks.map(t =>
+                                t.id === action.taskId ? { ...t, locked: true } : t,
+                            ),
+                        }
+                        : m,
+                ),
+            };
+
+        case 'SET_ACTIVE_MISSION': {
+            // Timer expired — deactivate. Tasks are intentionally left as-is
+            // (they're reset when the mission re-triggers via SET_ACTIVE_MISSION).
+            if (action.phase === 'none') {
+                return {
+                    ...state,
+                    activeMission: 'none',
+                    missions: state.missions.map(m => ({
+                        ...m,
+                        active: false,
+                        durationMins: undefined,
+                    })),
+                };
+            }
+
+            // Only one mission at a time — if one is already running, ignore the new trigger
+            if (state.activeMission !== 'none') {
+                return state;
+            }
+
+            const now = new Date().toISOString();
+            return {
+                ...state,
+                activeMission: action.phase,
+                missions: state.missions.map(m => {
+                    if (m.phase !== action.phase) return { ...m, active: false };
+                    // Every trigger is a fresh start: new timer, reset checklist.
+                    const [sh, sm] = m.startsAt.split(':').map(Number);
+                    const [eh, em] = m.endsAt.split(':').map(Number);
+                    const durationMins = (eh * 60 + em) - (sh * 60 + sm);
+                    return {
+                        ...m,
+                        active: true,
+                        startedAt: now,
+                        durationMins: Math.max(0, durationMins), // no minimum — allows sub-minute test durations
+                        tasks: m.tasks.map(t => ({ ...t, completed: false, locked: false })),
+                    };
+                }),
+            };
+        }
+
+        // Reset task progress only — mission stays active, timer keeps running.
+        // Does NOT affect startedAt/durationMins/activeMission.
+        case 'RESET_MISSION':
+            return {
+                ...state,
+                missions: state.missions.map(m =>
+                    m.phase === action.missionPhase
+                        ? { ...m, active: true, loggedTimeoutAt: undefined, tasks: m.tasks.map(t => ({ ...t, completed: false, locked: false })) }
+                        : m
+                )
+            };
+
+        // Full reset — tasks AND timer restart from scratch.
+        // Mission stays active with a fresh startedAt + recalculated durationMins.
+        case 'RESET_MISSION_WITH_TIMER': {
+            const now = new Date().toISOString();
+            return {
+                ...state,
+                missions: state.missions.map(m => {
+                    if (m.phase !== action.missionPhase) return m;
+                    const [sh, sm] = m.startsAt.split(':').map(Number);
+                    const [eh, em] = m.endsAt.split(':').map(Number);
+                    let durationMins = (eh * 60 + em) - (sh * 60 + sm);
+                    if (durationMins < 0) durationMins += 24 * 60; // overnight wrap
+                    return {
+                        ...m,
+                        active: true,
+                        startedAt: now,
+                        durationMins,
+                        loggedTimeoutAt: undefined,
+                        tasks: m.tasks.map(t => ({ ...t, completed: false, locked: false })),
+                    };
+                }),
+            };
+        }
+
+        case 'CANCEL_MISSION':
+            return {
+                ...state,
+                activeMission: 'none',
+                missions: state.missions.map(m =>
+                    m.phase === action.missionPhase
+                        ? { ...m, startedAt: undefined, active: false, loggedTimeoutAt: undefined, tasks: m.tasks.map(t => ({ ...t, completed: false, locked: false })) }
+                        : m
+                )
+            };
+
+        case 'COMPLETE_MISSION_ROUTINE':
+            return {
+                ...state,
+                activeMission: 'none',
+                bankCount: state.bankCount + action.bonusTokens,
+                missions: state.missions.map(m =>
+                    m.phase === action.missionPhase
+                        ? { ...m, startedAt: undefined, active: false, loggedTimeoutAt: undefined, tasks: m.tasks.map(t => ({ ...t, completed: false, locked: false })) }
+                        : m
+                )
+            };
+
+        case 'MARK_MISSION_TIMEOUT':
+            return {
+                ...state,
+                missions: state.missions.map(m =>
+                    m.phase === action.missionPhase
+                        ? { ...m, loggedTimeoutAt: new Date().toISOString() }
+                        : m
+                )
+            };
+
+        case 'ADJUST_MISSION_END': {
+            return {
+                ...state,
+                missions: state.missions.map(m => {
+                    if (m.phase !== action.missionPhase) return m;
+                    // Adjust durationMins if mission already started; otherwise adjust endsAt HH:MM
+                    if (m.startedAt && m.durationMins != null) {
+                        return { ...m, durationMins: Math.max(1, m.durationMins + action.deltaMinutes) };
+                    }
+                    const [hh, mm] = m.endsAt.split(':').map(Number);
+                    const totalMins = Math.max(0, Math.min(23 * 60 + 59, hh * 60 + mm + action.deltaMinutes));
+                    const newH = String(Math.floor(totalMins / 60)).padStart(2, '0');
+                    const newM = String(totalMins % 60).padStart(2, '0');
+                    return { ...m, endsAt: `${newH}:${newM}` };
+                }),
+            };
+        }
+
+        default:
+            return state;
+    }
+}

--- a/src/mission-control/store/reducers/privilegeReducer.ts
+++ b/src/mission-control/store/reducers/privilegeReducer.ts
@@ -1,0 +1,18 @@
+import { MCState, MCAction } from '../../types';
+
+export function reducePrivileges(state: MCState, action: MCAction): MCState {
+    switch (action.type) {
+        case 'SET_PRIVILEGE_STATUS':
+            return {
+                ...state,
+                privileges: state.privileges.map(p =>
+                    p.id === action.cardId
+                        ? { ...p, status: action.status, suspendedUntil: action.suspendedUntil }
+                        : p,
+                ),
+            };
+
+        default:
+            return state;
+    }
+}

--- a/src/mission-control/store/reducers/responsibilityReducer.ts
+++ b/src/mission-control/store/reducers/responsibilityReducer.ts
@@ -1,0 +1,39 @@
+import { MCState, MCAction } from '../../types';
+
+export function reduceResponsibilities(state: MCState, action: MCAction): MCState {
+    switch (action.type) {
+        case 'ADD_RESPONSIBILITY_POINT': {
+            const now = new Date().toISOString();
+            return {
+                ...state,
+                responsibilities: state.responsibilities.map(r => {
+                    if (r.id !== action.taskId) return r;
+                    if (r.completedAt) return r; // already complete — ignore
+                    const newPoints = r.pointsEarned + 1;
+                    const isComplete = newPoints >= r.pointsRequired;
+                    return {
+                        ...r,
+                        pointsEarned: newPoints,
+                        completedAt: isComplete ? now : null,
+                    };
+                }),
+            };
+        }
+
+        case 'RESET_RESPONSIBILITY': {
+            const addedBank = action.claimTokens ? state.bankCount + action.claimTokens : state.bankCount;
+            return {
+                ...state,
+                bankCount: addedBank,
+                responsibilities: state.responsibilities.map(r =>
+                    r.id === action.taskId
+                        ? { ...r, pointsEarned: 0, completedAt: null }
+                        : r
+                )
+            };
+        }
+
+        default:
+            return state;
+    }
+}

--- a/src/mission-control/store/reducers/securityReducer.ts
+++ b/src/mission-control/store/reducers/securityReducer.ts
@@ -1,0 +1,20 @@
+import { MCState, MCAction } from '../../types';
+
+export function reduceSecurity(state: MCState, action: MCAction): MCState {
+    switch (action.type) {
+        case 'CHEAT_ATTEMPT':
+            return {
+                ...state,
+                hasUnreviewedCheatAttempt: true,
+            };
+
+        case 'CLEAR_CHEAT_FLAG':
+            return {
+                ...state,
+                hasUnreviewedCheatAttempt: false,
+            };
+
+        default:
+            return state;
+    }
+}

--- a/src/mission-control/store/reducers/settingsReducer.ts
+++ b/src/mission-control/store/reducers/settingsReducer.ts
@@ -1,0 +1,72 @@
+import { MCState, MCAction } from '../../types';
+
+export function reduceSettings(state: MCState, action: MCAction): MCState {
+    switch (action.type) {
+        case 'SET_SETTINGS': {
+            const nextSettings = { ...state.settings, ...action.settings };
+            let nextDaysLeft = state.creamTaskDaysLeft;
+
+            if (action.settings.creamTaskEnabled && !state.settings.creamTaskEnabled) {
+                // Just enabled — start fresh
+                nextDaysLeft = nextSettings.creamTaskDaysTarget;
+            } else if (action.settings.creamTaskDaysTarget !== undefined && action.settings.creamTaskDaysTarget !== state.settings.creamTaskDaysTarget) {
+                 // Target changed, reset current progress
+                 nextDaysLeft = action.settings.creamTaskDaysTarget;
+            }
+
+            // If the start time of the currently-active mission changes, we must also
+            // deactivate it — otherwise durationMins is wiped but active stays true,
+            // making the expiry check `durationMins != null` permanently false (hung mission).
+            const mornTimeChanged =
+                (action.settings.morningStartsAt ?? state.settings.morningStartsAt) !== state.settings.morningStartsAt;
+            const evenTimeChanged =
+                (action.settings.eveningStartsAt ?? state.settings.eveningStartsAt) !== state.settings.eveningStartsAt;
+            const activeIsBeingRescheduled =
+                (state.activeMission === 'morning' && mornTimeChanged) ||
+                (state.activeMission === 'evening' && evenTimeChanged);
+
+            return {
+                ...state,
+                settings: nextSettings,
+                creamTaskDaysLeft: nextDaysLeft,
+                // Deactivate root if the running mission's start time was changed
+                ...(activeIsBeingRescheduled ? { activeMission: 'none' as const } : {}),
+                // Live-update mission startsAt/endsAt from settings so scheduler picks them up.
+                // If the start time changes, clear startedAt, durationMins, and active
+                // so the scheduler can re-trigger at the new time without getting stuck.
+                missions: state.missions.map(m => {
+                    if (m.phase === 'morning') {
+                        const dur = action.settings.morningDurationMins ?? state.settings.morningDurationMins;
+                        const start = action.settings.morningStartsAt ?? state.settings.morningStartsAt;
+                        const [h, min] = start.split(':').map(Number);
+                        const endTotal = h * 60 + min + dur;
+                        const endsAt = `${String(Math.floor(endTotal / 60)).padStart(2, '0')}:${String(endTotal % 60).padStart(2, '0')}`;
+                        return {
+                            ...m,
+                            startsAt: start,
+                            endsAt,
+                            ...(mornTimeChanged ? { startedAt: undefined, durationMins: undefined, active: false } : {}),
+                        };
+                    }
+                    if (m.phase === 'evening') {
+                        const dur = action.settings.eveningDurationMins ?? state.settings.eveningDurationMins;
+                        const start = action.settings.eveningStartsAt ?? state.settings.eveningStartsAt;
+                        const [h, min] = start.split(':').map(Number);
+                        const endTotal = h * 60 + min + dur;
+                        const endsAt = `${String(Math.floor(endTotal / 60)).padStart(2, '0')}:${String(endTotal % 60).padStart(2, '0')}`;
+                        return {
+                            ...m,
+                            startsAt: start,
+                            endsAt,
+                            ...(evenTimeChanged ? { startedAt: undefined, durationMins: undefined, active: false } : {}),
+                        };
+                    }
+                    return m;
+                }),
+            };
+        }
+
+        default:
+            return state;
+    }
+}


### PR DESCRIPTION
💡 **What**: Extracted the domain-specific reducer logic from the `mcReducer.ts` "God file" into a set of 7 focused domain reducers within a new `src/mission-control/store/reducers/` directory. The main `mcReducer` now delegates via pure `switch` statements to these sub-reducers.

🎯 **Why**: `mcReducer.ts` was over 600 lines long, tangling concerns like economy, mission state, settings, and logs together. This bloats context windows for agents and violates the Single Responsibility Principle (SRP).

♻️ **Refactor Details**:
- Created `economyReducer.ts`, `missionReducer.ts`, `responsibilityReducer.ts`, `settingsReducer.ts`, `logReducer.ts`, `privilegeReducer.ts`, and `securityReducer.ts`.
- Mapped all `MCAction` types cleanly to their respective domains.
- Retained the `MCState` interface and core logic intact.
- Appended a learning to `.jules/architect-journal.md`.

✅ **Verification**:
- `vitest run mcReducer` successfully ran 101 tests across 6 files with 100% pass rate.
- Linting and type checking completed successfully. No external business logic was changed.

---
*PR created automatically by Jules for task [6831898520943633772](https://jules.google.com/task/6831898520943633772) started by @natanbr*